### PR TITLE
Add "Mark all as read" feature for notifications

### DIFF
--- a/wsd-frontend/src/api/api.ts
+++ b/wsd-frontend/src/api/api.ts
@@ -209,4 +209,8 @@ export class WSDAPI {
   public async patchNotification(id: string, data: APIType<'PatchedNotificationUpdateRequest'>) {
     return await this.client.PATCH('/v0/notifications/{id}/', { params: { path: { id } }, body: data })
   }
+
+  public async markAllNotificationsAsRead() {
+    return await this.client.POST('/v0/notifications/mark_all_as_read/', {})
+  }
 }

--- a/wsd-frontend/src/api/api.ts
+++ b/wsd-frontend/src/api/api.ts
@@ -211,6 +211,6 @@ export class WSDAPI {
   }
 
   public async markAllNotificationsAsRead() {
-    return await this.client.POST('/v0/notifications/mark_all_as_read/', {})
+    return await this.client.POST('/v0/notifications/mark-all-as-read/', {})
   }
 }

--- a/wsd-frontend/src/api/schema.ts
+++ b/wsd-frontend/src/api/schema.ts
@@ -52,7 +52,7 @@ export interface paths {
     patch: operations['notifications_partial_update']
     trace?: never
   }
-  '/v0/notifications/mark_all_as_read/': {
+  '/v0/notifications/mark-all-as-read/': {
     parameters: {
       query?: never
       header?: never

--- a/wsd-frontend/src/api/schema.ts
+++ b/wsd-frontend/src/api/schema.ts
@@ -52,6 +52,26 @@ export interface paths {
     patch: operations['notifications_partial_update']
     trace?: never
   }
+  '/v0/notifications/mark_all_as_read/': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Mark all notifications as read
+     * @description Marks all notifications for the current user as read
+     */
+    post: operations['notifications_mark_all_as_read_create']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v0/post-categories/': {
     parameters: {
       query?: never
@@ -562,6 +582,33 @@ export interface components {
     NotificationObjectOfInterestRequest:
       | components['schemas']['PostRequest']
       | components['schemas']['PostCommentRequest']
+    /** @description Serializes the nested field, doesn't turn the serializer into read-only automatically(should it?) but it is
+     *     read only.
+     *
+     *     GET /api/v1/people/5/
+     *     {
+     *         "id": 5,
+     *         "first_name": "John",
+     *         "last_name": "Doe",
+     *         "labels": [7]
+     *     }
+     *
+     *     GET /api/v1/people/5/?include=labels
+     *     {
+     *         "id": 5,
+     *         "first_name": "John",
+     *         "last_name": "Doe",
+     *         "labels": [
+     *             {
+     *                 "id": 7,
+     *                 "name": "label-name"
+     *             }
+     *         ]
+     *     } */
+    NotificationRequest: {
+      /** @description Whether the notification has been read or not. */
+      is_read?: boolean
+    }
     /** @description Serializes the nested field, doesn't turn the serializer into read-only automatically(should it?) but it is
      *     read only.
      *
@@ -1545,6 +1592,50 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['Forbidden']
+        }
+      }
+    }
+  }
+  notifications_mark_all_as_read_create: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['NotificationRequest']
+        'application/x-www-form-urlencoded': components['schemas']['NotificationRequest']
+        'multipart/form-data': components['schemas']['NotificationRequest']
+      }
+    }
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            message?: string
+          }
+        }
+      }
+      /** @description No response body */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {
+            detail?: string
+          }
         }
       }
     }

--- a/wsd-frontend/src/api/schema.yml
+++ b/wsd-frontend/src/api/schema.yml
@@ -274,6 +274,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/Forbidden'
           description: ''
+  /v0/notifications/mark_all_as_read/:
+    post:
+      operationId: notifications_mark_all_as_read_create
+      description: Marks all notifications for the current user as read
+      summary: Mark all notifications as read
+      tags:
+      - notifications
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/NotificationRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/NotificationRequest'
+      security:
+      - tokenAuth: []
+      - basicAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+          description: ''
+        '401':
+          description: No response body
+        '403':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+          description: ''
   /v0/post-categories/:
     get:
       operationId: post_categories_list
@@ -1936,6 +1979,36 @@ components:
       oneOf:
       - $ref: '#/components/schemas/PostRequest'
       - $ref: '#/components/schemas/PostCommentRequest'
+    NotificationRequest:
+      type: object
+      description: |-
+        Serializes the nested field, doesn't turn the serializer into read-only automatically(should it?) but it is
+        read only.
+
+        GET /api/v1/people/5/
+        {
+            "id": 5,
+            "first_name": "John",
+            "last_name": "Doe",
+            "labels": [7]
+        }
+
+        GET /api/v1/people/5/?include=labels
+        {
+            "id": 5,
+            "first_name": "John",
+            "last_name": "Doe",
+            "labels": [
+                {
+                    "id": 7,
+                    "name": "label-name"
+                }
+            ]
+        }
+      properties:
+        is_read:
+          type: boolean
+          description: Whether the notification has been read or not.
     NotificationUpdateRequest:
       type: object
       description: |-

--- a/wsd-frontend/src/api/schema.yml
+++ b/wsd-frontend/src/api/schema.yml
@@ -274,7 +274,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Forbidden'
           description: ''
-  /v0/notifications/mark_all_as_read/:
+  /v0/notifications/mark-all-as-read/:
     post:
       operationId: notifications_mark_all_as_read_create
       description: Marks all notifications for the current user as read

--- a/wsd-frontend/src/components/wsd/Notifications/Notification.tsx
+++ b/wsd-frontend/src/components/wsd/Notifications/Notification.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import * as Icons from 'lucide-react'
 
@@ -19,6 +19,12 @@ export function Notification({ notification }: { notification: APIType<'Notifica
   const router = useRouter()
 
   const [isRead, setIsRead] = useState(notification.is_read)
+
+  useEffect(() => {
+    if (notification.is_read) {
+      setIsRead(notification.is_read)
+    }
+  }, [notification.is_read])
 
   const icons = {
     LIKE: Icons.Heart,

--- a/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
+++ b/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
@@ -63,36 +63,30 @@ export function Notifications({ hasNew }: { hasNew?: boolean }) {
   }
 
   async function markAllAsRead() {
-    return await wsd.markAllNotificationsAsRead()
-  }
-
-  function onMarkAllAsRead() {
-    markAllAsRead()
-      .then((data) => {
-        const { error } = data
-        if (error) {
-          const errors = error as { detail: string }
-          toast(errors.detail, {
-            description: 'There was an error marking notifications as read.',
-          })
-          return
-        }
-
-        setNotifications((prev) => {
-          return prev.map((notification) => ({
-            ...notification,
-            is_read: true,
-          }))
-        })
-        toast(data.data?.message || 'Notifications marked as read')
-        setHasNewState(false)
-      })
-      .catch((error) => {
-        console.error('Error marking notifications as read:', error)
-        toast('Error marking notifications as read', {
+    try {
+      const data = await wsd.markAllNotificationsAsRead()
+      const { error } = data
+      if (error) {
+        const errors = error as { detail: string }
+        toast(errors.detail, {
           description: 'There was an error marking notifications as read.',
         })
+        return
+      }
+      setNotifications((prev) => {
+        return prev.map((notification) => ({
+          ...notification,
+          is_read: true,
+        }))
       })
+      toast(data.data?.message || 'Notifications marked as read')
+      setHasNewState(false)
+    } catch (error) {
+      console.error('Error marking notifications as read:', error)
+      toast('Error marking notifications as read', {
+        description: 'There was an error marking notifications as read.',
+      })
+    }
   }
 
   return (
@@ -110,12 +104,7 @@ export function Notifications({ hasNew }: { hasNew?: boolean }) {
         <OverlayDescription className="hidden">Notifications</OverlayDescription>
         <ScrollArea className="max-h-[50vh] overflow-auto">
           {!loading && hasNewState && (
-            <Button
-              className="flex items-center gap-2 w-full"
-              variant={'outline'}
-              onClick={onMarkAllAsRead}
-              size={'sm'}
-            >
+            <Button className="flex items-center gap-2 w-full" variant="outline" onClick={markAllAsRead} size={'sm'}>
               <Icons.CheckCircle className="h-3 w-3" />
               Mark all as read
             </Button>

--- a/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
+++ b/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
@@ -39,10 +39,10 @@ export function Notifications({ hasNew }: { hasNew?: boolean }) {
       ordering: '-created_at',
       include: 'post',
     })
-    setNotifications((prev) => {
-      const newNotifications = [...prev, ...(notificationsData?.results || [])]
-      return _.uniqBy(newNotifications, 'id')
-    })
+    const newNotifications = _.uniqBy([...notifications, ...(notificationsData?.results || [])], 'id')
+
+    setHasNewState(_.some(newNotifications, (notification) => !notification.is_read))
+    setNotifications(newNotifications)
     setHasMore(page !== notificationsData?.total_pages)
     setLoading(false)
   }

--- a/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
+++ b/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
@@ -18,6 +18,7 @@ import { APIType } from '@/api'
 import { useWSDAPI } from '@/lib/serverHooks'
 
 import { useInView } from 'react-intersection-observer'
+import { toast } from 'sonner'
 
 export function Notifications({ hasNew }: { hasNew?: boolean }) {
   const wsd = useWSDAPI()
@@ -26,6 +27,7 @@ export function Notifications({ hasNew }: { hasNew?: boolean }) {
   const [page, setPage] = useState(1)
   const [loading, setLoading] = useState(false)
   const [hasMore, setHasMore] = useState(true)
+  const [hasNewState, setHasNewState] = useState(hasNew)
 
   const { ref: loaderRef, inView } = useInView()
 
@@ -60,13 +62,46 @@ export function Notifications({ hasNew }: { hasNew?: boolean }) {
     }
   }
 
+  async function markAllAsRead() {
+    return await wsd.markAllNotificationsAsRead()
+  }
+
+  function onMarkAllAsRead() {
+    markAllAsRead()
+      .then((data) => {
+        const { error } = data
+        if (error) {
+          const errors = error as { detail: string }
+          toast(errors.detail, {
+            description: 'There was an error marking notifications as read.',
+          })
+          return
+        }
+
+        setNotifications((prev) => {
+          return prev.map((notification) => ({
+            ...notification,
+            is_read: true,
+          }))
+        })
+        toast(data.data?.message || 'Notifications marked as read')
+        setHasNewState(false)
+      })
+      .catch((error) => {
+        console.error('Error marking notifications as read:', error)
+        toast('Error marking notifications as read', {
+          description: 'There was an error marking notifications as read.',
+        })
+      })
+  }
+
   return (
     <Overlay breakpoint="md" onOpenChange={onOverlayOpenChange}>
       <OverlayTrigger asChild>
         <Button variant="ghost" className="flex gap-2 h-10 w-10 rounded-full p-2">
           <div className="relative">
             <Icons.Bell size={20} />
-            {hasNew && <span className="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-red-600 border" />}
+            {hasNewState && <span className="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-red-600 border" />}
           </div>
         </Button>
       </OverlayTrigger>
@@ -74,6 +109,17 @@ export function Notifications({ hasNew }: { hasNew?: boolean }) {
         <OverlayTitle className="hidden">Notifications</OverlayTitle>
         <OverlayDescription className="hidden">Notifications</OverlayDescription>
         <ScrollArea className="max-h-[50vh] overflow-auto">
+          {!loading && hasNewState && (
+            <Button
+              className="flex items-center gap-2 w-full"
+              variant={'outline'}
+              onClick={onMarkAllAsRead}
+              size={'sm'}
+            >
+              <Icons.CheckCircle className="h-3 w-3" />
+              Mark all as read
+            </Button>
+          )}
           {notifications.map((notification) => (
             <div className="contents" key={notification.id}>
               <Notification notification={notification} />

--- a/wsd/apps/rest/v0/views/notification.py
+++ b/wsd/apps/rest/v0/views/notification.py
@@ -35,19 +35,18 @@ class NotificationViewSet(BaseModelViewSet):
             403: {"type": "object", "properties": {"detail": {"type": "string"}}},
         },
     )
-    @action(detail=False, methods=["post"])
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="mark-all-as-read",
+        permission_classes=[IsAuthenticatedANDSignupCompleted],
+    )
     def mark_all_as_read(self, request):
         """Mark all notifications as read for the current user."""
         user = request.user
-        if not user.is_authenticated:
-            return Response(
-                {"detail": "Authentication credentials were not provided."}, status=status.HTTP_401_UNAUTHORIZED
-            )
 
-        # Get all unread notifications for the user
         notifications = self.get_queryset().filter(is_read=False)
 
-        # Update all notifications to mark them as read
         count = notifications.update(is_read=True)
 
         return Response({"message": f"Successfully marked {count} notifications as read."}, status=status.HTTP_200_OK)

--- a/wsd/apps/rest/v0/views/notification.py
+++ b/wsd/apps/rest/v0/views/notification.py
@@ -1,6 +1,10 @@
 from apps.core.models import Notification
 from apps.rest.utils.permissions import IsAuthenticatedANDSignupCompleted, IsSuperUser, is_owner
 from apps.rest.v0.serializers import NotificationSerializer
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from .base import BaseModelViewSet
 
@@ -21,3 +25,29 @@ class NotificationViewSet(BaseModelViewSet):
     def get_queryset(self):
         user = self.request.user
         return self.model.objects.filter(user=user) if user.is_authenticated else self.model.objects.none()
+
+    @extend_schema(
+        summary="Mark all notifications as read",
+        description="Marks all notifications for the current user as read",
+        responses={
+            200: {"type": "object", "properties": {"message": {"type": "string"}}},
+            401: None,
+            403: {"type": "object", "properties": {"detail": {"type": "string"}}},
+        },
+    )
+    @action(detail=False, methods=["post"])
+    def mark_all_as_read(self, request):
+        """Mark all notifications as read for the current user."""
+        user = request.user
+        if not user.is_authenticated:
+            return Response(
+                {"detail": "Authentication credentials were not provided."}, status=status.HTTP_401_UNAUTHORIZED
+            )
+
+        # Get all unread notifications for the user
+        notifications = self.get_queryset().filter(is_read=False)
+
+        # Update all notifications to mark them as read
+        count = notifications.update(is_read=True)
+
+        return Response({"message": f"Successfully marked {count} notifications as read."}, status=status.HTTP_200_OK)


### PR DESCRIPTION
Introduce an API endpoint and frontend functionality to mark all notifications as read. Updated the backend view, API schema, and frontend components to support this feature, including notification state management and user feedback with toast messages.

This is my first backend addition. Please let me know if it is wrong. 


And p.s. i will stop for now until the PRs are getting less.