### PR TITLE
Remove redundant loading check in notifications button logic

### DIFF
--- a/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
+++ b/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
@@ -103,7 +103,7 @@ export function Notifications({ hasNew }: { hasNew?: boolean }) {
         <OverlayTitle className="hidden">Notifications</OverlayTitle>
         <OverlayDescription className="hidden">Notifications</OverlayDescription>
         <ScrollArea className="max-h-[50vh] overflow-auto">
-          {!loading && hasNewState && (
+          {hasNewState && (
             <Button className="flex items-center gap-2 w-full" variant="outline" onClick={markAllAsRead} size={'sm'}>
               <Icons.CheckCircle className="h-3 w-3" />
               Mark all as read


### PR DESCRIPTION
The `loading` check was removed as it was unnecessary for rendering the "Mark all as read" button. The `hasNewState` condition alone is sufficient to determine when the button should be displayed. This simplifies the logic and ensures clarity.

So that it isnt "flashing" up when the loading state takes long time to go to loaded.