### PR TITLE
Refactor WSD API hook usage to standardize method access.

### DIFF
--- a/wsd-frontend/src/app/(app)/posts/[hex]/page.tsx
+++ b/wsd-frontend/src/app/(app)/posts/[hex]/page.tsx
@@ -16,13 +16,13 @@ import NewComment from '@/components/wsd/NewComment'
 import { APIQuery, APIType, includesType } from '@/api'
 import config from '@/config'
 import { getWSDMetadata } from '@/lib/metadata'
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 import { getKeys } from '@/lib/typeHelpers'
 import { InvalidHEXError, cn, hexToUUIDv4, suppress } from '@/lib/utils'
 
 export async function generateMetadata(props: { params: Promise<{ hex: string }> }): Promise<Metadata | undefined> {
   const params = await props.params
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const postId = suppress<string, undefined>([InvalidHEXError], () => hexToUUIDv4(params.hex))
 
   if (!_.isUndefined(postId)) {
@@ -44,7 +44,7 @@ export default async function PostPage(props: {
 }) {
   const searchParams = await props.searchParams
   const params = await props.params
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const isAuthenticated = await wsd.isAuthenticated()
   const postId = suppress<string, undefined>([InvalidHEXError], () => hexToUUIDv4(params.hex))
 

--- a/wsd-frontend/src/app/(app)/profile/(tabs)/layout.tsx
+++ b/wsd-frontend/src/app/(app)/profile/(tabs)/layout.tsx
@@ -7,10 +7,10 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/shadcn/tabs'
 import UserAvatar from '@/components/wsd/UserAvatar'
 
 import { APIType } from '@/api'
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export default async function ProfileLayout({ children }: { children: React.ReactNode }) {
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
 
   const { data: user } = await wsd.me()
 

--- a/wsd-frontend/src/app/(app)/users/[username]/page.tsx
+++ b/wsd-frontend/src/app/(app)/users/[username]/page.tsx
@@ -5,7 +5,7 @@ import UserProfile from '@/components/wsd/UserProfile'
 
 import { APIQuery, APIType } from '@/api'
 import config from '@/config'
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export default async function User(props: {
   params: Promise<{ username: string }>
@@ -13,7 +13,7 @@ export default async function User(props: {
 }) {
   const { username } = await props.params
   const searchParams = await props.searchParams
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const { data: users } = await wsd.users({ username })
 
   if (wsd.hasResults(users)) {

--- a/wsd-frontend/src/app/(home)/page.tsx
+++ b/wsd-frontend/src/app/(home)/page.tsx
@@ -2,11 +2,11 @@ import Memes from '@/components/wsd/Memes'
 
 import { APIQuery } from '@/api'
 import config from '@/config'
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export default async function Home(props: { searchParams?: Promise<APIQuery<'/v0/posts/'>> }) {
   const searchParams = await props.searchParams
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const isAuthenticated = await wsd.isAuthenticated()
   const postQuery = {
     ...searchParams,

--- a/wsd-frontend/src/components/wsd/Auth/ForgotPassword/client/ForgotPasswordForm.tsx
+++ b/wsd-frontend/src/components/wsd/Auth/ForgotPassword/client/ForgotPasswordForm.tsx
@@ -9,12 +9,12 @@ import { Input } from '@/components/shadcn/input'
 import { Label } from '@/components/shadcn/label'
 
 import { useFormState } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
 export default function RequestPasswordForm() {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   const {

--- a/wsd-frontend/src/components/wsd/Auth/Login/Login.tsx
+++ b/wsd-frontend/src/components/wsd/Auth/Login/Login.tsx
@@ -7,7 +7,7 @@ import { LoginForm } from '@/components/wsd/Auth/Login/client'
 import { AutoFormButton } from '@/components/wsd/AutoFormButton/AutoFormButton'
 
 import config from '@/config'
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export async function Login() {
   const providers = [
@@ -17,7 +17,7 @@ export async function Login() {
     { name: 'Discord', icon: Brands.Discord, id: 'discord' },
     { name: 'Reddit', icon: Brands.Reddit, id: 'reddit' },
   ]
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   return (
     <>
       <Card className="max-w-md w-full">

--- a/wsd-frontend/src/components/wsd/Auth/Login/client/LoginForm.tsx
+++ b/wsd-frontend/src/components/wsd/Auth/Login/client/LoginForm.tsx
@@ -13,12 +13,12 @@ import { Label } from '@/components/shadcn/label'
 import PasswordInput from '@/components/wsd/PasswordInput'
 
 import { useFormState } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
 export default function LoginForm() {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
   const [loginDisabled, setLoginDisabled] = useState<boolean>(false)
 

--- a/wsd-frontend/src/components/wsd/Auth/PasswordReset/client/PasswordResetForm.tsx
+++ b/wsd-frontend/src/components/wsd/Auth/PasswordReset/client/PasswordResetForm.tsx
@@ -9,12 +9,12 @@ import { Label } from '@/components/shadcn/label'
 import PasswordInput from '@/components/wsd/PasswordInput'
 
 import { useFormState } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
 export default function PasswordResetForm({ passwordResetKey }: { passwordResetKey: string }) {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   const {

--- a/wsd-frontend/src/components/wsd/Auth/Signup/Signup.tsx
+++ b/wsd-frontend/src/components/wsd/Auth/Signup/Signup.tsx
@@ -7,7 +7,7 @@ import { SignupForm } from '@/components/wsd/Auth/Signup/client'
 import { AutoFormButton } from '@/components/wsd/AutoFormButton/AutoFormButton'
 
 import config from '@/config'
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export async function Signup() {
   const providers = [
@@ -17,7 +17,7 @@ export async function Signup() {
     { name: 'Discord', icon: Brands.Discord, id: 'discord' },
     { name: 'Reddit', icon: Brands.Reddit, id: 'reddit' },
   ]
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const tos = (
     <Link href={{ pathname: '/legal/terms-of-service' }} className="text-white hover:underline transition">
       Terms of Service

--- a/wsd-frontend/src/components/wsd/Auth/Signup/client/SignupForm.tsx
+++ b/wsd-frontend/src/components/wsd/Auth/Signup/client/SignupForm.tsx
@@ -12,12 +12,12 @@ import { Label } from '@/components/shadcn/label'
 import PasswordInput from '@/components/wsd/PasswordInput'
 
 import { useFormState } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
 export default function SignupForm() {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
   const [registrationDisabled, setRegistrationDisabled] = useState<boolean>(false)
 

--- a/wsd-frontend/src/components/wsd/Auth/VerifyEmail/client/VerifyButton.tsx
+++ b/wsd-frontend/src/components/wsd/Auth/VerifyEmail/client/VerifyButton.tsx
@@ -6,7 +6,7 @@ import _ from 'lodash'
 
 import { Button } from '@/components/shadcn/button'
 
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
@@ -14,7 +14,7 @@ export default function VerifyButton(
   props: Omit<React.ComponentPropsWithoutRef<typeof Button>, 'onClick'> & { verificationKey: string }
 ) {
   const { children, verificationKey, ...buttonProps } = props
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   async function handleVerify() {

--- a/wsd-frontend/src/components/wsd/AutoFormButton/AutoFormButton.tsx
+++ b/wsd-frontend/src/components/wsd/AutoFormButton/AutoFormButton.tsx
@@ -6,7 +6,7 @@ import _ from 'lodash'
 
 import { Button } from '@/components/shadcn/button'
 
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 import { getLazyValueAsync } from '@/lib/utils'
 
 // TODO@next15: Remove forwardRef and turn this back to a function component
@@ -18,7 +18,7 @@ export const AutoFormButton = forwardRef<
     payload?: Record<string, string>
   }
 >(({ action, method = 'POST', payload = {}, children, ...buttonProps }, ref) => {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const formRef = useRef<HTMLFormElement | null>(null)
 
   async function handleClick() {

--- a/wsd-frontend/src/components/wsd/Header/Header.tsx
+++ b/wsd-frontend/src/components/wsd/Header/Header.tsx
@@ -10,11 +10,11 @@ import UserAvatar from '@/components/wsd/UserAvatar'
 
 import { APIType } from '@/api'
 import config from '@/config'
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 import { cn } from '@/lib/utils'
 
 export async function Header() {
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const user = (await wsd.getCurrentUser()) as APIType<'User'>
   const { data: notifications } = await wsd.notifications({ is_read: false })
 

--- a/wsd-frontend/src/components/wsd/LeftColumn/LeftColumn.tsx
+++ b/wsd-frontend/src/components/wsd/LeftColumn/LeftColumn.tsx
@@ -4,10 +4,10 @@ import { RawSVGIcon } from '@/components/shadcn/raw-svg-icon'
 import { Separator } from '@/components/shadcn/separator'
 import CategoryLink from '@/components/wsd/CategoryLink'
 
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export async function LeftColumn() {
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const { data: postCategoriesData } = await wsd.postCategories()
 
   function getQuickFilterHREF(params?: { [key: string]: string }) {

--- a/wsd-frontend/src/components/wsd/LogoutButton/client/LogoutButton.tsx
+++ b/wsd-frontend/src/components/wsd/LogoutButton/client/LogoutButton.tsx
@@ -4,13 +4,13 @@ import { useRouter } from 'next/navigation'
 
 import { Button } from '@/components/shadcn/button'
 
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
 export default function LogoutButton(props: Omit<React.ComponentPropsWithoutRef<typeof Button>, 'onClick'>) {
   const { children, ...buttonProps } = props
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   async function handleLogout() {

--- a/wsd-frontend/src/components/wsd/Meme/client/FeedbackButtons.tsx
+++ b/wsd-frontend/src/components/wsd/Meme/client/FeedbackButtons.tsx
@@ -10,7 +10,7 @@ import { Button, buttonVariants } from '@/components/shadcn/button'
 import AuthenticatedOnlyActionButton from '@/components/wsd/AuthenticatedOnlyActionButton'
 
 import { APIType, Includes } from '@/api/typeHelpers'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 import { cn, uuidV4toHEX } from '@/lib/utils'
 
 import { toast } from 'sonner'
@@ -22,7 +22,7 @@ export default function FeedbackButtons({
   post: Includes<Includes<APIType<'Post'>, 'user', APIType<'User'>>, 'tags', APIType<'PostTag'>[]>
   isAuthenticated: boolean
 }) {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const [feedback, setFeedback] = useState<APIType<'VoteEnum'> | null>(post.vote)
   const [voteCount, setVoteCount] = useState((post.positive_vote_count || 0) - (post.negative_vote_count || 0))
   const [isBookmarked, setIsBookmarked] = useState<boolean>(post.bookmarked)

--- a/wsd-frontend/src/components/wsd/MemeComment/MemeComment.tsx
+++ b/wsd-frontend/src/components/wsd/MemeComment/MemeComment.tsx
@@ -11,14 +11,14 @@ import UserAvatar from '@/components/wsd/UserAvatar'
 import { WSDEditorRenderer } from '@/components/wsd/WSDEditor/Editor'
 
 import type { APIType, Includes } from '@/api'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 import { cn, shortFormattedDateTime } from '@/lib/utils'
 
 import { formatDistanceToNow } from 'date-fns'
 import { toast } from 'sonner'
 
 export function MemeComment({ comment }: { comment: Includes<APIType<'PostComment'>, 'user', APIType<'User'>> }) {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const [feedback, setFeedback] = useState<APIType<'VoteEnum'> | null>(comment.vote)
   const [voteCount, setVoteCount] = useState((comment.positive_vote_count || 0) - (comment.negative_vote_count || 0))
 

--- a/wsd-frontend/src/components/wsd/Memes/Memes.tsx
+++ b/wsd-frontend/src/components/wsd/Memes/Memes.tsx
@@ -16,7 +16,7 @@ import { APIQuery, APIType } from '@/api'
 import { includesType as includes } from '@/api/typeHelpers'
 import config from '@/config'
 import { useEffectAfterMount } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 import { cn } from '@/lib/utils'
 
 import { useInView } from 'react-intersection-observer'
@@ -32,7 +32,7 @@ export function Memes({
   hasMorePages?: boolean
   isAuthenticated?: boolean
 }) {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const searchParams = useSearchParams()
 
   const defaultQuery = { page_size: config.ux.defaultPostPerPage }

--- a/wsd-frontend/src/components/wsd/NewComment/NewComment.tsx
+++ b/wsd-frontend/src/components/wsd/NewComment/NewComment.tsx
@@ -1,14 +1,14 @@
 import { NewCommentForm } from '@/components/wsd/NewComment/client'
 
 import { APIType, Includes } from '@/api'
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export async function NewComment({
   post,
 }: {
   post: Includes<Includes<APIType<'Post'>, 'user', APIType<'User'>>, 'tags', APIType<'PostTag'>[]>
 }) {
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const user = (await wsd.getCurrentUser()) as APIType<'User'>
   return <NewCommentForm post={post} user={user} />
 }

--- a/wsd-frontend/src/components/wsd/NewComment/client/NewCommentForm.tsx
+++ b/wsd-frontend/src/components/wsd/NewComment/client/NewCommentForm.tsx
@@ -10,7 +10,7 @@ import UserAvatar from '@/components/wsd/UserAvatar'
 import { WSDEditor, isEditorEmpty, stripEmptyParagraphs, useWSDEditor } from '@/components/wsd/WSDEditor'
 
 import { APIType, Includes } from '@/api'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
@@ -21,7 +21,7 @@ export default function NewCommentForm({
   post: Includes<Includes<APIType<'Post'>, 'user', APIType<'User'>>, 'tags', APIType<'PostTag'>[]>
   user: APIType<'User'>
 }) {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
   const editor = useWSDEditor({})
   const [loading, setLoading] = useState(false)

--- a/wsd-frontend/src/components/wsd/NewPost/NewPost.tsx
+++ b/wsd-frontend/src/components/wsd/NewPost/NewPost.tsx
@@ -1,9 +1,9 @@
 import { NewPostForm } from '@/components/wsd/NewPost/client'
 
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export async function NewPost() {
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const { data: postCategoriesData } = await wsd.postCategories()
 
   return <NewPostForm categories={postCategoriesData?.results || []} />

--- a/wsd-frontend/src/components/wsd/NewPost/client/NewPostForm.tsx
+++ b/wsd-frontend/src/components/wsd/NewPost/client/NewPostForm.tsx
@@ -18,14 +18,14 @@ import { Switch } from '@/components/shadcn/switch'
 
 import { APIType } from '@/api'
 import { useFormState } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 import { fileToBase64, uuidV4toHEX } from '@/lib/utils'
 
 import { Tag, TagInput } from 'emblor'
 import { toast } from 'sonner'
 
 export default function NewPostForm({ categories }: { categories: APIType<'PostCategory'>[] }) {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
   const fileInputRef = useRef<FileInputButtonRef>(null)
 

--- a/wsd-frontend/src/components/wsd/Notifications/Notification.tsx
+++ b/wsd-frontend/src/components/wsd/Notifications/Notification.tsx
@@ -8,14 +8,14 @@ import { useEffect, useState } from 'react'
 import * as Icons from 'lucide-react'
 
 import { APIType, Includes } from '@/api'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 import { forcedType } from '@/lib/typeHelpers'
 import { shortFormattedDateTime, uuidV4toHEX } from '@/lib/utils'
 
 import { formatDistanceToNow } from 'date-fns'
 
 export function Notification({ notification }: { notification: APIType<'Notification'> }) {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   const [isRead, setIsRead] = useState(notification.is_read)

--- a/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
+++ b/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
@@ -15,13 +15,13 @@ import { Skeleton } from '@/components/shadcn/skeleton'
 import { Notification } from '@/components/wsd/Notifications/Notification'
 
 import { APIType } from '@/api'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { useInView } from 'react-intersection-observer'
 import { toast } from 'sonner'
 
 export function Notifications({ hasNew }: { hasNew?: boolean }) {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
 
   const [notifications, setNotifications] = useState<APIType<'Notification'>[]>([])
   const [page, setPage] = useState(1)

--- a/wsd-frontend/src/components/wsd/Profile/CompleteSignup/client/CompleteSignupForm.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/CompleteSignup/client/CompleteSignupForm.tsx
@@ -8,12 +8,12 @@ import { Label } from '@/components/shadcn/label'
 import PasswordInput from '@/components/wsd/PasswordInput'
 
 import { useFormState } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
 export default function CompleteSignupForm() {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   const {

--- a/wsd-frontend/src/components/wsd/Profile/Connections/Connections.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Connections/Connections.tsx
@@ -10,10 +10,10 @@ import { AutoFormButton } from '@/components/wsd/AutoFormButton/AutoFormButton'
 import { DisconnectButton } from '@/components/wsd/Profile/Connections/client'
 
 import config from '@/config'
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export async function Connections() {
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const { data } = await wsd.auth.connections()
   const connections = data?.data as { uid: string; display: string; provider: { id: string; name: string } }[]
   const connectedAccounts: string[] = connections ? _.map(connections, 'provider.id') : []

--- a/wsd-frontend/src/components/wsd/Profile/Connections/client/DisconnectButton.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Connections/client/DisconnectButton.tsx
@@ -6,7 +6,7 @@ import _ from 'lodash'
 
 import { Button } from '@/components/shadcn/button'
 
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
@@ -14,7 +14,7 @@ export default function DisconnectButton(
   props: Omit<React.ComponentPropsWithoutRef<typeof Button>, 'onClick'> & { provider: string; account: string }
 ) {
   const { provider, account, children, ...buttonProps } = props
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   async function handleDisconnect() {

--- a/wsd-frontend/src/components/wsd/Profile/Details/Details.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Details/Details.tsx
@@ -5,12 +5,12 @@ import * as Icons from 'lucide-react'
 import LogoutButton from '@/components/wsd/LogoutButton'
 import { InfoItem } from '@/components/wsd/Profile/Details/InfoItem'
 
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { format } from 'date-fns'
 
 export async function Details() {
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const { data: userData } = await wsd.me()
   return (
     userData && (

--- a/wsd-frontend/src/components/wsd/Profile/Emails/Emails.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Emails/Emails.tsx
@@ -12,10 +12,10 @@ import {
   ResendVerificationEmailButton,
 } from '@/components/wsd/Profile/Emails/client'
 
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export async function Emails() {
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const { data } = await wsd.auth.emails()
   const emails = data?.data as { email: string; primary: boolean; verified: boolean }[] | undefined
   return (

--- a/wsd-frontend/src/components/wsd/Profile/Emails/client/AddEmailForm.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Emails/client/AddEmailForm.tsx
@@ -9,12 +9,12 @@ import { Input } from '@/components/shadcn/input'
 import { Label } from '@/components/shadcn/label'
 
 import { useFormState } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
 export default function AddEmailForm() {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   const {

--- a/wsd-frontend/src/components/wsd/Profile/Emails/client/DeleteEmailButton.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Emails/client/DeleteEmailButton.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation'
 
 import { Button } from '@/components/shadcn/button'
 
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
@@ -12,7 +12,7 @@ export default function DeleteEmailButton(
   props: Omit<React.ComponentPropsWithoutRef<typeof Button>, 'onClick'> & { email: string }
 ) {
   const { email, children, ...buttonProps } = props
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   async function handleDeleteEmail() {

--- a/wsd-frontend/src/components/wsd/Profile/Emails/client/MarkEmailPrimaryButton.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Emails/client/MarkEmailPrimaryButton.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation'
 
 import { Button } from '@/components/shadcn/button'
 
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
@@ -12,7 +12,7 @@ export default function MarkEmailPrimaryButton(
   props: Omit<React.ComponentPropsWithoutRef<typeof Button>, 'onClick'> & { email: string }
 ) {
   const { email, children, ...buttonProps } = props
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   async function handleMarkEmailPrimary() {

--- a/wsd-frontend/src/components/wsd/Profile/Emails/client/ResendVerificationEmailButton.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Emails/client/ResendVerificationEmailButton.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@/components/shadcn/button'
 
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
@@ -10,7 +10,7 @@ export default function ResendVerificationEmailButton(
   props: Omit<React.ComponentPropsWithoutRef<typeof Button>, 'onClick'> & { email: string }
 ) {
   const { email, children, ...buttonProps } = props
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
 
   async function handleResendVerificationEmail() {
     const { error } = await wsd.auth.resendVerificationEmail({ email })

--- a/wsd-frontend/src/components/wsd/Profile/Password/Password.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Password/Password.tsx
@@ -2,10 +2,10 @@
 
 import { ChangePasswordForm, SetPasswordForm } from '@/components/wsd/Profile/Password/client'
 
-import { useWSDAPI as sUseWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 export async function Password() {
-  const wsd = sUseWSDAPI()
+  const wsd = getWSDAPI()
   const { data } = await wsd.auth.session()
   const hasPassword = (data?.data as Record<'user', Record<'has_usable_password', boolean>>).user?.has_usable_password
   return (

--- a/wsd-frontend/src/components/wsd/Profile/Password/client/ChangePasswordForm.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Password/client/ChangePasswordForm.tsx
@@ -9,12 +9,12 @@ import { Label } from '@/components/shadcn/label'
 import PasswordInput from '@/components/wsd/PasswordInput'
 
 import { useFormState } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
 export default function ChangePasswordForm() {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   const {

--- a/wsd-frontend/src/components/wsd/Profile/Password/client/SetPasswordForm.tsx
+++ b/wsd-frontend/src/components/wsd/Profile/Password/client/SetPasswordForm.tsx
@@ -9,12 +9,12 @@ import { Label } from '@/components/shadcn/label'
 import PasswordInput from '@/components/wsd/PasswordInput'
 
 import { useFormState } from '@/lib/hooks'
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { toast } from 'sonner'
 
 export default function SetPasswordForm() {
-  const wsd = useWSDAPI()
+  const wsd = getWSDAPI()
   const router = useRouter()
 
   const {

--- a/wsd-frontend/src/components/wsd/WSDEditor/WSDMentionsExtension.ts
+++ b/wsd-frontend/src/components/wsd/WSDEditor/WSDMentionsExtension.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-import { useWSDAPI as getWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 
 import { MentionItem, MentionList, MentionListProps } from './WSDMentions'
 import Mention from '@tiptap/extension-mention'

--- a/wsd-frontend/src/lib/serverHooks.ts
+++ b/wsd-frontend/src/lib/serverHooks.ts
@@ -2,7 +2,7 @@ import { WSDAPI } from '@/api'
 import config from '@/config'
 import { getCookie } from '@/lib/serverActions'
 
-export function useWSDAPI() {
+export function getWSDAPI() {
   return new WSDAPI(
     () => getCookie(config.api.sessionCookieName) || null,
     () => getCookie(config.api.csrfTokenCookieName) || null

--- a/wsd-frontend/src/middlewares/authMiddlewares.ts
+++ b/wsd-frontend/src/middlewares/authMiddlewares.ts
@@ -1,12 +1,12 @@
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-import { useWSDAPI } from '@/lib/serverHooks'
+import { getWSDAPI } from '@/lib/serverHooks'
 import { runMiddlewareIfPathMatches } from '@/lib/utils'
 
 export function redirectAuthenticatedIncompleteSignup(path: RegExp, redirectTo: string) {
   return runMiddlewareIfPathMatches(path)(async function (request: NextRequest) {
-    const wsd = useWSDAPI()
+    const wsd = getWSDAPI()
     const isAuthenticated = await wsd.isAuthenticated()
     const signupCompleted = await wsd.signupCompleted()
     if (isAuthenticated && !signupCompleted) {
@@ -17,7 +17,7 @@ export function redirectAuthenticatedIncompleteSignup(path: RegExp, redirectTo: 
 
 export function redirectAuthenticatedBackTo(path: RegExp, redirectTo: string) {
   return runMiddlewareIfPathMatches(path)(async function (request: NextRequest) {
-    const wsd = useWSDAPI()
+    const wsd = getWSDAPI()
     const isAuthenticated = await wsd.isAuthenticated()
     if (isAuthenticated) {
       return NextResponse.redirect(new URL(redirectTo, request.url))
@@ -27,7 +27,7 @@ export function redirectAuthenticatedBackTo(path: RegExp, redirectTo: string) {
 
 export function redirectAnonymousBackTo(path: RegExp, redirectTo: string) {
   return runMiddlewareIfPathMatches(path)(async function (request: NextRequest) {
-    const wsd = useWSDAPI()
+    const wsd = getWSDAPI()
     const isAuthenticated = await wsd.isAuthenticated()
     if (!isAuthenticated) {
       return NextResponse.redirect(new URL(redirectTo, request.url))


### PR DESCRIPTION
Replaced `useWSDAPI` with `getWSDAPI` across the codebase for consistency and clarity. This update ensures uniformity in accessing the WSD API, simplifying future maintenance and reducing ambiguity.

Fixes #23