### PR TITLE
Disable autocomplete and autocorrect on input fields during Meme creation ( Title and Url )

### DIFF
--- a/wsd-frontend/src/components/wsd/NewPost/client/NewPostForm.tsx
+++ b/wsd-frontend/src/components/wsd/NewPost/client/NewPostForm.tsx
@@ -112,6 +112,10 @@ export default function NewPostForm({ categories }: { categories: APIType<'PostC
               value={postState.title}
               onChange={handlePostStateEvent('title')}
               errorText={postErrors?.title?.join('\n')}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              aria-autocomplete="none"
             />
           </div>
           {categories.length > 0 && (
@@ -185,6 +189,10 @@ export default function NewPostForm({ categories }: { categories: APIType<'PostC
                 value={postState.original_source}
                 onChange={handlePostStateEvent('original_source')}
                 errorText={postErrors?.original_source?.join('\n')}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                aria-autocomplete="none"
               />
             </div>
             <small className="text-muted-foreground">Meme's youtube/reddit/blog link</small>


### PR DESCRIPTION
Added `autoComplete`, `autoCorrect`, `autoCapitalize`(only disabled on title), and `aria-autocomplete` attributes to input fields for title and original source. This ensures a better user experience by preventing unwanted browser suggestions or corrections.