### PR TITLE
Add BackToTopButton component to homepage

### DIFF
--- a/wsd-frontend/src/app/(home)/page.tsx
+++ b/wsd-frontend/src/app/(home)/page.tsx
@@ -1,3 +1,4 @@
+import BackToTopButton from '@/components/wsd/BackToTopButton/client'
 import Memes from '@/components/wsd/Memes'
 
 import { APIQuery } from '@/api'
@@ -16,11 +17,14 @@ export default async function Home(props: { searchParams?: Promise<APIQuery<'/v0
   }
   const { data } = await wsd.posts(postQuery)
   return (
-    <Memes
-      query={postQuery}
-      initialPosts={data?.results || []}
-      hasMorePages={Boolean(data?.total_pages && data.total_pages > 1)}
-      isAuthenticated={isAuthenticated}
-    />
+    <>
+      <Memes
+        query={postQuery}
+        initialPosts={data?.results || []}
+        hasMorePages={Boolean(data?.total_pages && data.total_pages > 1)}
+        isAuthenticated={isAuthenticated}
+      />
+      <BackToTopButton />
+    </>
   )
 }

--- a/wsd-frontend/src/components/wsd/BackToTopButton/client/BackToTopButton.tsx
+++ b/wsd-frontend/src/components/wsd/BackToTopButton/client/BackToTopButton.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import * as Icons from 'lucide-react'
+
+import { Button } from '@/components/shadcn/button'
+
+import { cn } from '@/lib/utils'
+
+export function BackToTopButton() {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      // Show button when user scrolls down 200 px
+      if (window.scrollY > 200) {
+        setIsVisible(true)
+      } else {
+        setIsVisible(false)
+      }
+    }
+
+    window.addEventListener('scroll', toggleVisibility)
+
+    // Clean up the event listener on component unmount
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility)
+    }
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }
+
+  return (
+    <Button
+      variant={'outline'}
+      className={cn(
+        'fixed bottom-8 right-8 z-50 rounded-full transition-opacity duration-300 ease-in-out px-2',
+        isVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      )}
+      onClick={scrollToTop}
+    >
+      <Icons.ArrowUp size={24} className="h-6 w-6" aria-hidden="true" />
+    </Button>
+  )
+}

--- a/wsd-frontend/src/components/wsd/BackToTopButton/client/index.ts
+++ b/wsd-frontend/src/components/wsd/BackToTopButton/client/index.ts
@@ -1,0 +1,1 @@
+export { BackToTopButton as default } from './BackToTopButton'

--- a/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
+++ b/wsd-frontend/src/components/wsd/Notifications/Notifications.tsx
@@ -22,7 +22,7 @@ import { toast } from 'sonner'
 
 export function Notifications({ hasNew }: { hasNew?: boolean }) {
   const wsd = useWSDAPI()
-
+  const [open, setOpen] = useState(false)
   const [notifications, setNotifications] = useState<APIType<'Notification'>[]>([])
   const [page, setPage] = useState(1)
   const [loading, setLoading] = useState(false)
@@ -48,17 +48,19 @@ export function Notifications({ hasNew }: { hasNew?: boolean }) {
   }
 
   useEffect(() => {
-    if (inView && hasMore && !loading) {
+    if (open && inView && hasMore && !loading) {
       setPage((prev) => prev + 1)
       fetchNotifications(page)
     }
-  }, [inView, hasMore, loading]) // eslint-disable-line react-hooks/exhaustive-deps -- what we have is enough
+  }, [inView, hasMore, loading, open]) // eslint-disable-line react-hooks/exhaustive-deps -- what we have is enough
 
   function onOverlayOpenChange(open: boolean) {
+    setOpen(open)
     if (!open) {
-      setNotifications([])
       setPage(1)
+      setNotifications([])
       setHasMore(true)
+      setLoading(false)
     }
   }
 
@@ -103,7 +105,7 @@ export function Notifications({ hasNew }: { hasNew?: boolean }) {
         <OverlayTitle className="hidden">Notifications</OverlayTitle>
         <OverlayDescription className="hidden">Notifications</OverlayDescription>
         <ScrollArea className="max-h-[50vh] overflow-auto">
-          {hasNewState && (
+          {hasNewState && !loading && (
             <Button className="flex items-center gap-2 w-full" variant="outline" onClick={markAllAsRead} size={'sm'}>
               <Icons.CheckCircle className="h-3 w-3" />
               Mark all as read


### PR DESCRIPTION
Introduced a reusable BackToTopButton component that appears after scrolling down and smooth scrolls to the top when clicked. Integrated the component into the homepage to enhance navigation and user experience.

Implements #38