### PR TITLE
Add support for pasting images in `NewPostForm`.

### DIFF
--- a/wsd-frontend/src/components/shadcn/file-input-button.tsx
+++ b/wsd-frontend/src/components/shadcn/file-input-button.tsx
@@ -1,19 +1,20 @@
-"use client"
+'use client'
 
-import type React from "react"
-import {forwardRef, useEffect, useImperativeHandle, useRef, useState} from "react"
-import {Button} from "@/components/shadcn/button"
-import {Upload} from "lucide-react"
+import type React from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { Button } from '@/components/shadcn/button'
+import { Upload } from 'lucide-react'
 
 export type FileInputButtonRef = {
   getFile: () => File | null
   hasFile: () => boolean
+  setFile: (file: File | null) => void
 }
 
 const FileInputButton = forwardRef(
-  function (
-    {onFileSelect, id, previewPosition="top"}:
-    { onFileSelect?: (file: File | null) => Promise<void>, id?: string, previewPosition?: "top" | "bottom" }, ref
+  function(
+    { onFileSelect, id, previewPosition = 'top' }:
+    { onFileSelect?: (file: File | null) => Promise<void>, id?: string, previewPosition?: 'top' | 'bottom' }, ref,
   ) {
     const [imagePreview, setImagePreview] = useState<string | null>(null)
     const fileInputRef = useRef<HTMLInputElement>(null)
@@ -45,25 +46,37 @@ const FileInputButton = forwardRef(
     useImperativeHandle(ref, () => ({
       getFile: () => selectedFile,
       hasFile: () => !!selectedFile,
+      setFile: (file: File | null) => {
+        if (file) {
+          const imageUrl = URL.createObjectURL(file)
+          setImagePreview(imageUrl)
+          setSelectedFile(file)
+          onFileSelect?.(file)
+        } else {
+          setImagePreview(null)
+          setSelectedFile(null)
+          onFileSelect?.(null)
+        }
+      },
     }))
 
     return (
       <div className="flex flex-col items-center gap-4">
-        {imagePreview && previewPosition === "top" && (
+        {imagePreview && previewPosition === 'top' && (
           <img src={imagePreview} alt="Selected preview" className="mt-2 w-full object-cover rounded-lg shadow" />
         )}
         <Button onClick={handleButtonClick} variant="outline" role="button" type="button">
           <Upload className="mr-2 h-4 w-4" />
-          {imagePreview ? "Change Image" : "Choose a file..."}
+          {imagePreview ? 'Change Image' : 'Choose a file...'}
         </Button>
         <input type="file" id={id} ref={fileInputRef} onChange={handleFileChange} className="hidden" accept="image/*" />
-        {imagePreview && previewPosition === "bottom" && (
+        {imagePreview && previewPosition === 'bottom' && (
           <img src={imagePreview} alt="Selected preview" className="mt-2 w-full object-cover rounded-lg shadow" />
         )}
       </div>
     )
-  }
+  },
 )
 
 export default FileInputButton
-FileInputButton.displayName = "FileInputButton"
+FileInputButton.displayName = 'FileInputButton'

--- a/wsd-frontend/src/components/wsd/NewPost/client/NewPostForm.tsx
+++ b/wsd-frontend/src/components/wsd/NewPost/client/NewPostForm.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 
-import { SetStateAction, useRef, useState, useTransition } from 'react'
+import { SetStateAction, useEffect, useRef, useState, useTransition } from 'react'
 
 import * as Icons from 'lucide-react'
 
@@ -47,6 +47,32 @@ export default function NewPostForm({ categories }: { categories: APIType<'PostC
       handlePostStateValue('image')(await fileToBase64(file))
     }
   }
+
+  async function handlePaste(e: ClipboardEvent) {
+    const items = e.clipboardData?.items
+
+    if (!items) {
+      return
+    }
+
+    // Check if the clipboard contains image data
+    const imageFile = Array.from(items)
+      .find((item) => item.type.startsWith('image/') && item.kind === 'file' && item.getAsFile() !== null)
+      ?.getAsFile()
+
+    if (imageFile) {
+      e.preventDefault()
+      if (fileInputRef.current) {
+        fileInputRef.current.setFile(imageFile)
+      }
+      toast.success('Image pasted successfully!')
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener('paste', handlePaste)
+    return () => window.removeEventListener('paste', handlePaste)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps -- We want this to run only once on mount
 
   const {
     formState: postState,


### PR DESCRIPTION
Extended the `FileInputButton` functionality with a `setFile` method to support managing file state programmatically. Enhanced `NewPostForm` to handle image pasting via clipboard, providing user feedback on success. Adjusted code formatting for consistency.

Known bug: 

On Flatpak Firefox Linux, if you try pasting an image from your local drive, firefox doesnt count it as image / file somehow. Flatpak Chrome on Linux doesnt has the issue. 