### PR TITLE
Add drag-and-drop functionality for image upload

### DIFF
--- a/wsd-frontend/src/components/shadcn/file-input-button.tsx
+++ b/wsd-frontend/src/components/shadcn/file-input-button.tsx
@@ -1,19 +1,20 @@
-"use client"
+'use client'
 
-import type React from "react"
-import {forwardRef, useEffect, useImperativeHandle, useRef, useState} from "react"
-import {Button} from "@/components/shadcn/button"
-import {Upload} from "lucide-react"
+import type React from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { Button } from '@/components/shadcn/button'
+import { Upload } from 'lucide-react'
 
 export type FileInputButtonRef = {
   getFile: () => File | null
   hasFile: () => boolean
+  setFile: (file: File | null) => void
 }
 
 const FileInputButton = forwardRef(
-  function (
-    {onFileSelect, id, previewPosition="top"}:
-    { onFileSelect?: (file: File | null) => Promise<void>, id?: string, previewPosition?: "top" | "bottom" }, ref
+  function(
+    { onFileSelect, id, previewPosition = 'top' }:
+    { onFileSelect?: (file: File | null) => Promise<void>, id?: string, previewPosition?: 'top' | 'bottom' }, ref,
   ) {
     const [imagePreview, setImagePreview] = useState<string | null>(null)
     const fileInputRef = useRef<HTMLInputElement>(null)
@@ -45,25 +46,37 @@ const FileInputButton = forwardRef(
     useImperativeHandle(ref, () => ({
       getFile: () => selectedFile,
       hasFile: () => !!selectedFile,
+      setFile: (file: File | null) => {
+        if (file) {
+          const imageUrl = URL.createObjectURL(file)
+          setImagePreview(imageUrl)
+          setSelectedFile(file)
+          onFileSelect?.(file)
+        } else {
+          setImagePreview(null)
+          setSelectedFile(null)
+          onFileSelect?.(null)
+        }
+      },
     }))
 
     return (
       <div className="flex flex-col items-center gap-4">
-        {imagePreview && previewPosition === "top" && (
+        {imagePreview && previewPosition === 'top' && (
           <img src={imagePreview} alt="Selected preview" className="mt-2 w-full object-cover rounded-lg shadow" />
         )}
         <Button onClick={handleButtonClick} variant="outline" role="button" type="button">
           <Upload className="mr-2 h-4 w-4" />
-          {imagePreview ? "Change Image" : "Choose a file..."}
+          {imagePreview ? 'Change Image' : 'Choose a file...'}
         </Button>
         <input type="file" id={id} ref={fileInputRef} onChange={handleFileChange} className="hidden" accept="image/*" />
-        {imagePreview && previewPosition === "bottom" && (
+        {imagePreview && previewPosition === 'bottom' && (
           <img src={imagePreview} alt="Selected preview" className="mt-2 w-full object-cover rounded-lg shadow" />
         )}
       </div>
     )
-  }
+  },
 )
 
 export default FileInputButton
-FileInputButton.displayName = "FileInputButton"
+FileInputButton.displayName = 'FileInputButton'

--- a/wsd-frontend/src/components/wsd/NewPost/client/NewPostForm.tsx
+++ b/wsd-frontend/src/components/wsd/NewPost/client/NewPostForm.tsx
@@ -19,7 +19,7 @@ import { Switch } from '@/components/shadcn/switch'
 import { APIType } from '@/api'
 import { useFormState } from '@/lib/hooks'
 import { useWSDAPI } from '@/lib/serverHooks'
-import { cn, fileToBase64, uuidV4toHEX } from '@/lib/utils'
+import { cn, fileToBase64, getImageFromDataTransfer, uuidV4toHEX } from '@/lib/utils'
 
 import { Tag, TagInput } from 'emblor'
 import { toast } from 'sonner'
@@ -100,12 +100,7 @@ export default function NewPostForm({ categories }: { categories: APIType<'PostC
   }
 
   function handleDragOver(event: React.DragEvent<HTMLFormElement>) {
-    if (
-      !event.dataTransfer ||
-      !event.dataTransfer.items ||
-      event.dataTransfer.items.length === 0 ||
-      !Array.from(event.dataTransfer.items).some((item) => item.kind === 'file' && item.type.startsWith('image/'))
-    ) {
+    if (!getImageFromDataTransfer(event.dataTransfer)) {
       return
     }
     event.preventDefault()
@@ -120,7 +115,7 @@ export default function NewPostForm({ categories }: { categories: APIType<'PostC
   }
 
   function handleDrop(event: React.DragEvent<HTMLFormElement>) {
-    const file = Array.from(event.dataTransfer.files).find((file) => file.type.startsWith('image/')) || null
+    const file = getImageFromDataTransfer(event.dataTransfer)
     if (file) {
       event.preventDefault()
       event.stopPropagation()

--- a/wsd-frontend/src/lib/hooks.ts
+++ b/wsd-frontend/src/lib/hooks.ts
@@ -145,3 +145,191 @@ export function useEffectAfterMount(effect: EffectCallback, deps: DependencyList
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps)
 }
+
+type FileDragDropState = {
+  isDragging: boolean
+  files: File[] | null
+}
+
+type FileDragDropOptions = {
+  onDrop?: (files: File[]) => void
+  onDragOver?: (e: React.DragEvent<HTMLElement>) => void
+  onDragLeave?: (e: React.DragEvent<HTMLElement>) => void
+  acceptedFileTypes?: string[]
+  maxFileSize?: number
+  multiple?: boolean
+}
+
+export function useFileDragDrop<T extends HTMLElement = HTMLDivElement>(options: FileDragDropOptions = {}) {
+  /***
+   * A hook to handle file drag and drop functionality.
+   * It provides a ref to attach to an element, and state to track dragging and dropped files.
+   *
+   * Usage:
+   * const { ref, isDragging, files, reset } = useFileDragDrop({
+   *   onDrop: (files) => console.log(files),
+   *   acceptedFileTypes: ['image/*', 'application/pdf'],
+   *   maxFileSize: 5000000, // 5MB
+   * });
+   *
+   * <div ref={ref}>Drop files here</div>
+   */
+  const { onDrop, onDragOver, onDragLeave, acceptedFileTypes, maxFileSize, multiple = true } = options
+
+  const [state, setState] = useState<FileDragDropState>({
+    isDragging: false,
+    files: null,
+  })
+
+  const ref = useRef<T | null>(null)
+  const dragCounter = useRef(0)
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent<T>) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      onDragOver?.(e)
+    },
+    [onDragOver]
+  )
+
+  const handleDragEnter = useCallback(
+    (e: React.DragEvent<T>) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      dragCounter.current += 1
+
+      if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
+        const hasValidItems = Array.from(e.dataTransfer.items).some((item) => {
+          if (item.kind !== 'file') {
+            return false
+          }
+
+          if (acceptedFileTypes && acceptedFileTypes.length > 0) {
+            return acceptedFileTypes.some((type) => {
+              if (type.endsWith('/*')) {
+                const category = type.split('/')[0]
+                return item.type.startsWith(`${category}/`)
+              }
+              return item.type === type
+            })
+          }
+
+          return true
+        })
+
+        if (hasValidItems) {
+          setState((prevState) => ({
+            ...prevState,
+            isDragging: true,
+          }))
+        }
+      }
+    },
+    [acceptedFileTypes]
+  )
+
+  const handleDragLeave = useCallback(
+    (e: React.DragEvent<T>) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      dragCounter.current -= 1
+
+      if (dragCounter.current === 0) {
+        setState((prevState) => ({
+          ...prevState,
+          isDragging: false,
+        }))
+      }
+
+      onDragLeave?.(e)
+    },
+    [onDragLeave]
+  )
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<T>) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      dragCounter.current = 0
+      setState((prevState) => ({
+        ...prevState,
+        isDragging: false,
+      }))
+
+      if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        let validFiles = Array.from(e.dataTransfer.files)
+
+        if (acceptedFileTypes && acceptedFileTypes.length > 0) {
+          validFiles = validFiles.filter((file) =>
+            acceptedFileTypes.some((type) => {
+              // Handle wildcards like "image/*"
+              if (type.endsWith('/*')) {
+                const category = type.split('/')[0]
+                return file.type.startsWith(`${category}/`)
+              }
+              return file.type === type
+            })
+          )
+        }
+
+        // Filter by file size if specified
+        if (maxFileSize) {
+          validFiles = validFiles.filter((file) => file.size <= maxFileSize)
+        }
+
+        // Limit to a single file if multiple is false
+        if (!multiple && validFiles.length > 0) {
+          validFiles = [validFiles[0]]
+        }
+
+        if (validFiles.length > 0) {
+          setState((prevState) => ({
+            ...prevState,
+            files: validFiles,
+          }))
+
+          onDrop?.(validFiles)
+        }
+      }
+    },
+    [onDrop, acceptedFileTypes, maxFileSize, multiple]
+  )
+
+  // Attach and clean up event listeners
+  useEffect(() => {
+    const currentRef = ref.current
+    if (currentRef) {
+      currentRef.addEventListener('dragover', handleDragOver as unknown as EventListener)
+      currentRef.addEventListener('dragenter', handleDragEnter as unknown as EventListener)
+      currentRef.addEventListener('dragleave', handleDragLeave as unknown as EventListener)
+      currentRef.addEventListener('drop', handleDrop as unknown as EventListener)
+
+      return () => {
+        currentRef.removeEventListener('dragover', handleDragOver as unknown as EventListener)
+        currentRef.removeEventListener('dragenter', handleDragEnter as unknown as EventListener)
+        currentRef.removeEventListener('dragleave', handleDragLeave as unknown as EventListener)
+        currentRef.removeEventListener('drop', handleDrop as unknown as EventListener)
+      }
+    }
+    return undefined
+  }, [handleDragOver, handleDragEnter, handleDragLeave, handleDrop])
+
+  const reset = useCallback(() => {
+    setState({
+      isDragging: false,
+      files: null,
+    })
+  }, [])
+
+  return {
+    ref,
+    isDragging: state.isDragging,
+    files: state.files,
+    reset,
+  }
+}

--- a/wsd-frontend/src/lib/utils.ts
+++ b/wsd-frontend/src/lib/utils.ts
@@ -261,15 +261,3 @@ export function noopLayout() {
     return React.createElement(React.Fragment, null, children)
   }
 }
-
-export function getImageFromDataTransfer(dataTransfer: DataTransfer): File | null {
-  /**
-   * Get the first image file from a DataTransfer object.
-   * Used for drag-and-drop file uploads.
-   */
-  if (dataTransfer.files.length > 0) {
-    const files = Array.from(dataTransfer.files)
-    return files.find((file) => file.type.startsWith('image/')) || null
-  }
-  return null
-}

--- a/wsd-frontend/src/lib/utils.ts
+++ b/wsd-frontend/src/lib/utils.ts
@@ -261,3 +261,15 @@ export function noopLayout() {
     return React.createElement(React.Fragment, null, children)
   }
 }
+
+export function getImageFromDataTransfer(dataTransfer: DataTransfer): File | null {
+  /**
+   * Get the first image file from a DataTransfer object.
+   * Used for drag-and-drop file uploads.
+   */
+  if (dataTransfer.files.length > 0) {
+    const files = Array.from(dataTransfer.files)
+    return files.find((file) => file.type.startsWith('image/')) || null
+  }
+  return null
+}


### PR DESCRIPTION
Enhanced `NewPostForm` to support drag-and-drop image upload with visual feedback. Updated `FileInputButton` with a new `setFile` method for directly setting a file and managing its preview.