### PR TITLE
Add RSS and Atom feeds for latest posts

### DIFF
--- a/wsd-frontend/src/app/(app)/posts/layout.tsx
+++ b/wsd-frontend/src/app/(app)/posts/layout.tsx
@@ -19,7 +19,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
           <div className="relative flex min-h-screen flex-col bg-background">
             <div className="border-b">
               <div className="container flex-1 items-start xl:grid xl:grid-cols-[240px_minmax(0,1fr)_240px] max-md:px-0">
-                <aside className="fixed top-14 z-30 -ml-2 hidden h-[calc(100dvh-10rem)] w-full shrink-0 xl:sticky xl:block">
+                <aside className="fixed top-14 z-30 -ml-2 hidden h-[calc(100dvh-11rem)] w-full shrink-0 xl:sticky xl:block">
                   <ScrollArea className="h-full py-6 pr-6">
                     <LeftColumn />
                     <ScrollBar orientation="vertical" />
@@ -50,6 +50,22 @@ export default async function Layout({ children }: { children: React.ReactNode }
                         GitHub
                       </Link>
                     )}
+                    <div className="flex flex-row gap-1">
+                      <Link
+                        className="text-muted-foreground text-sm hover:underline flex items-center gap-1 justify-between"
+                        href={config.api.baseURL + '/v0/feeds/latest/rss/'}
+                      >
+                        <Icons.Rss color="darkorange" size={18} className="mr-1" />
+                        RSS Feed
+                      </Link>{' '}
+                      /
+                      <Link
+                        className="text-muted-foreground text-sm hover:underline flex items-center gap-1 justify-between"
+                        href={config.api.baseURL + '/v0/feeds/latest/rss/'}
+                      >
+                        Atom Feed
+                      </Link>
+                    </div>
                   </div>
                 </aside>
                 <main className="flex min-h-screen flex-col items-center pt-2">{children}</main>

--- a/wsd-frontend/src/app/(app)/posts/layout.tsx
+++ b/wsd-frontend/src/app/(app)/posts/layout.tsx
@@ -61,7 +61,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
                       /
                       <Link
                         className="text-muted-foreground text-sm hover:underline flex items-center gap-1 justify-between"
-                        href={config.api.baseURL + '/v0/feeds/latest/rss/'}
+                        href={config.api.baseURL + '/v0/feeds/latest/atom/'}
                       >
                         Atom Feed
                       </Link>

--- a/wsd/apps/core/feeds.py
+++ b/wsd/apps/core/feeds.py
@@ -45,16 +45,12 @@ class LatestPostsFeed(Feed):
         return user_template_url % item.user.username
 
     def _item_category_link(self, item):
-        # Escape the category name to be URL-safe
         return (category_template_url % quote(item.category.handle, safe="")) if item.category else None
 
     def item_pubdate(self, item):
         return item.created_at
 
     def item_extra_kwargs(self, item):
-        """
-        Return extra keywords arguments for each item in the feed.
-        """
         return {
             "image_url": item.image.url if item.image else None,
             "category": item.category.name if item.category else None,

--- a/wsd/apps/core/feeds.py
+++ b/wsd/apps/core/feeds.py
@@ -1,0 +1,67 @@
+from urllib.parse import quote
+
+from apps.core.models import Post
+from django.contrib.syndication.views import Feed
+from django.utils.feedgenerator import Atom1Feed
+
+from wsd.config import CONFIG as config
+
+post_template_url = f"{config.PROTOCOL}://{config.HOSTS.DOMAIN}/posts/%s"
+user_template_url = f"{config.PROTOCOL}://{config.HOSTS.DOMAIN}/users/%s"
+category_template_url = f"{config.PROTOCOL}://{config.HOSTS.DOMAIN}/?category__handle=%s"
+
+
+class LatestPostsFeed(Feed):
+    title = "Latest Memes"
+    link = f"{config.PROTOCOL}://{config.HOSTS.DOMAIN}"
+    description = f"Latest memes from the site. Check out it at {config.PROTOCOL}://{config.HOSTS.DOMAIN}!"
+    language = "en"
+
+    def items(self):
+        return Post.objects.filter(is_nsfw=False).order_by("-created_at")[:20]
+
+    def item_title(self, item):
+        return item.title
+
+    def item_description(self, item):
+        description = f'Meme by <a href="{self._item_author_link(item)}">{item.user.username}</a> ( {f'<a href="{self._item_category_link(item)}">{item.category.name}</a>' if item.category else f'<a href="{config.PROTOCOL}://{config.HOSTS.DOMAIN}">Recent</a>'} )'
+        if item.image:
+            description += (
+                f'<br><br><img src="{item.image.url}" alt="{item.title}" width="{min(item.image.width, 300)}"/>'
+            )
+
+        if item.tags.exists():
+            tags = ", ".join(tag.name for tag in item.tags.all())
+            description += f"<br>Tags: {tags}"
+
+        description += f'<br><br><a href="{self.item_link(item)}">View Post</a>'
+
+        return description
+
+    def item_link(self, item):
+        return post_template_url % item.id.hex.replace("-", "")
+
+    def _item_author_link(self, item):
+        return user_template_url % item.user.username
+
+    def _item_category_link(self, item):
+        # Escape the category name to be URL-safe
+        return (category_template_url % quote(item.category.handle, safe="")) if item.category else None
+
+    def item_pubdate(self, item):
+        return item.created_at
+
+    def item_extra_kwargs(self, item):
+        """
+        Return extra keywords arguments for each item in the feed.
+        """
+        return {
+            "image_url": item.image.url if item.image else None,
+            "category": item.category.name if item.category else None,
+            "color": item.colorhash if item.colorhash else None,
+        }
+
+
+class AtomLatestPostsFeed(LatestPostsFeed):
+    feed_type = Atom1Feed
+    subtitle = LatestPostsFeed.description

--- a/wsd/apps/rest/v0/urls.py
+++ b/wsd/apps/rest/v0/urls.py
@@ -1,3 +1,4 @@
+from apps.core.feeds import AtomLatestPostsFeed, LatestPostsFeed
 from apps.rest.v0.views import (
     NotificationViewSet,
     PostCategoryViewSet,
@@ -34,6 +35,8 @@ v0_urlpatterns = [
         SpectacularRedocView.as_view(url=reverse_lazy(f"rest:v0:{SCHEMA_URL_NAME}")),
         name="redoc",
     ),
+    path("feeds/latest/rss/", LatestPostsFeed(), name="posts-rss"),
+    path("feeds/latest/atom/", AtomLatestPostsFeed(), name="posts-atom"),
     *router.urls,
 ]
 


### PR DESCRIPTION
Introduced `LatestPostsFeed` and `AtomLatestPostsFeed` to provide syndication feeds for the latest posts. Added corresponding routes for RSS and Atom feeds in API endpoints. Updated frontend layout to include feed links in the posts sidebar.